### PR TITLE
Build fixes for Windows / Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,18 @@ if (NDZIP_BUILD_BENCHMARK AND NDZIP_WITH_3RDPARTY_BENCHMARKS)
 endif ()
 
 
-set(CMAKE_CXX_STANDARD 17)
+if (NOT MSVC)
+    set(CMAKE_CXX_STANDARD 17)
+else ()
+    set(CMAKE_CXX_STANDARD 20) # to_string under MSVC needs C++20
+endif ()
+
 set(CMAKE_CUDA_STANDARD 17)
 
-set(NDZIP_COMPILE_FLAGS -Wall -Wextra -Wno-attributes -Wimplicit-fallthrough)
-set(NDZIP_CXX_FLAGS ${NDZIP_COMPILE_FLAGS} -Werror=return-type -Werror=init-self -Werror=undef)
+if (NOT MSVC)
+    set(NDZIP_COMPILE_FLAGS -Wall -Wextra -Wno-attributes -Wimplicit-fallthrough)
+    set(NDZIP_CXX_FLAGS ${NDZIP_COMPILE_FLAGS} -Werror=return-type -Werror=init-self -Werror=undef)
+endif()
 
 if (NDZIP_USE_HIPSYCL)
     # Aggressive inlining avoids GPU call stack allocation == global memory access bottleneck
@@ -107,7 +114,7 @@ set(NDZIP_PROFILE_CONFIGURATIONS
     VARIABLE DIMENSIONS VALUES 1 2 3
 )
 
-add_library(ndzip SHARED
+set(NDZIP_LIB_SOURCES
     include/ndzip/ndzip.hh
     include/ndzip/offload.hh
     src/ndzip/common.hh
@@ -115,6 +122,13 @@ add_library(ndzip SHARED
     src/ndzip/cpu_codec.inl
     src/ndzip/cpu_factory.cc
 )
+
+if (MSVC)
+    # on windows, build as static library since symbol exports are not setup there
+    add_library(ndzip STATIC ${NDZIP_LIB_SOURCES})
+else ()
+    add_library(ndzip SHARED ${NDZIP_LIB_SOURCES})
+endif ()
 target_split_configured_sources(ndzip PRIVATE
     GENERATE cpu_encoder.cc FROM src/ndzip/cpu_codec.inl
     ${NDZIP_PROFILE_CONFIGURATIONS}

--- a/src/ndzip/common.hh
+++ b/src/ndzip/common.hh
@@ -590,6 +590,8 @@ NDZIP_UNIVERSAL inline unsigned popcount(unsigned int x) {
 #ifdef __CUDA_ARCH__
     // NVCC regards __builtin_popcount as a __host__ function
     return __popc(static_cast<int>(x));
+#elif defined(_MSC_VER)
+    return __popcnt(x);
 #else
     return __builtin_popcount(x);
 #endif
@@ -604,6 +606,8 @@ NDZIP_UNIVERSAL inline unsigned popcount(unsigned long x) {
         static_assert(sizeof(unsigned long) == sizeof(unsigned long long));
         return __popcll(static_cast<long long>(x));
     }
+#elif defined(_MSC_VER)
+    return __popcnt64(x);
 #else
     return __builtin_popcountl(x);
 #endif
@@ -613,6 +617,8 @@ NDZIP_UNIVERSAL inline unsigned popcount(unsigned long long x) {
 #ifdef __CUDA_ARCH__
     // NVCC regards __builtin_popcountll as a __host__ function
     return __popcll(static_cast<long long>(x));
+#elif defined(_MSC_VER)
+    return __popcnt64(x);
 #else
     return __builtin_popcountll(x);
 #endif


### PR DESCRIPTION
- popcount() implementations
- workaround the lack of std::aligned_alloc
- fix cpu_coded.inl wrongly using #ifdef instead of #if for OpenMP flags (the flag is defined, just to zero). With OpenMP this does not yet compile on MSVC out of the box.
- cmake: when using MSVC, indicate C++ 20 (for to_string), do not pass gcc/clang warning flags, and build as static library since public symbols do not have "please export me" attributes set on them.